### PR TITLE
Use net.IPNet as DstIP in flower filter

### DIFF
--- a/pkg/tc/actuator_tc_test.go
+++ b/pkg/tc/actuator_tc_test.go
@@ -3,6 +3,8 @@ package tc_test
 import (
 	"flag"
 	"github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/tc/generator"
+	"github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/utils"
+	"net"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -154,17 +156,18 @@ var _ = Describe("Actuator TC tests", func() {
 	})
 
 	Context("Actuate with filters", func() {
+		ipToIpNet := func(ip string) *net.IPNet { ipn, _ := utils.IPToIPNet(ip); return ipn }
 		neededFilters := []tctypes.Filter{
 			tctypes.NewFlowerFilterBuilder().
 				WithProtocol(tctypes.FilterProtocolIPv4).
 				WithPriority(100).
-				WithMatchKeyDstIP("10.100.0.0/24").
+				WithMatchKeyDstIP(ipToIpNet("10.100.0.0/24")).
 				WithAction(tctypes.NewGenericActionBuiler().WithDrop().Build()).
 				Build(),
 			tctypes.NewFlowerFilterBuilder().
 				WithProtocol(tctypes.FilterProtocolIPv4).
 				WithPriority(200).
-				WithMatchKeyDstIP("10.100.0.0/16").
+				WithMatchKeyDstIP(ipToIpNet("10.100.0.0/16")).
 				WithAction(tctypes.NewGenericActionBuiler().WithPass().Build()).
 				Build(),
 		}
@@ -172,13 +175,13 @@ var _ = Describe("Actuator TC tests", func() {
 			tctypes.NewFlowerFilterBuilder().
 				WithProtocol(tctypes.FilterProtocolIPv4).
 				WithPriority(100).
-				WithMatchKeyDstIP("10.100.1.0/24").
+				WithMatchKeyDstIP(ipToIpNet("10.100.1.0/24")).
 				WithAction(tctypes.NewGenericActionBuiler().WithDrop().Build()).
 				Build(),
 			tctypes.NewFlowerFilterBuilder().
 				WithProtocol(tctypes.FilterProtocolIPv4).
 				WithPriority(200).
-				WithMatchKeyDstIP("10.100.0.0/16").
+				WithMatchKeyDstIP(ipToIpNet("10.100.0.0/16")).
 				WithAction(tctypes.NewGenericActionBuiler().WithPass().Build()).
 				Build(),
 		}

--- a/pkg/tc/driver/cmdline/tc_cmdline.go
+++ b/pkg/tc/driver/cmdline/tc_cmdline.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/utils/exec"
 
 	"github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/tc/types"
+	"github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/utils"
 )
 
 // NewTcCmdLineImpl creates a new instance of TcCmdLineImpl
@@ -157,7 +158,11 @@ func (t *TcCmdLineImpl) FilterList(qdisc types.QDisc) ([]types.Filter, error) {
 			fb.WithMatchKeyIPProto(sToFlowerIPProto(*f.Options.Keys.IPProto))
 		}
 		if f.Options.Keys.DstIP != nil {
-			fb.WithMatchKeyDstIP(*f.Options.Keys.DstIP)
+			ipn, err := utils.IPToIPNet(*f.Options.Keys.DstIP)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to parse dest IP: %s", *f.Options.Keys.DstIP)
+			}
+			fb.WithMatchKeyDstIP(ipn)
 		}
 		if f.Options.Keys.DstPort != nil {
 			fb.WithMatchKeyDstPort(*f.Options.Keys.DstPort)

--- a/pkg/tc/driver/cmdline/tc_cmdline_test.go
+++ b/pkg/tc/driver/cmdline/tc_cmdline_test.go
@@ -1,18 +1,20 @@
 package driver_test
 
 import (
-	"github.com/pkg/errors"
-	"k8s.io/klog/v2"
-	"k8s.io/utils/exec"
+	"net"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/exec"
 
 	testingexec "k8s.io/utils/exec/testing"
 
 	"github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/tc"
 	driver "github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/tc/driver/cmdline"
 	tctypes "github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/tc/types"
+	"github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/utils"
 )
 
 const (
@@ -47,6 +49,7 @@ var _ = Describe("TC Cmdline driver tests", func() {
 	var tcCmdLine tc.TC
 	var log = klog.NewKlogr().WithName("tc-driver-cmdline-test")
 	var testError = errors.New("test error!")
+	ipToIpNet := func(ip string) *net.IPNet { ipn, _ := utils.IPToIPNet(ip); return ipn }
 
 	BeforeEach(func() {
 		fakeExec = &fakeExecHelper{testingexec.FakeExec{}}
@@ -255,7 +258,7 @@ var _ = Describe("TC Cmdline driver tests", func() {
 		filterToAdd := tctypes.NewFlowerFilterBuilder().
 			WithProtocol(tctypes.FilterProtocolIPv4).
 			WithAction(tctypes.NewGenericActionBuiler().WithPass().Build()).
-			WithMatchKeyDstIP("10.10.10.2/24").
+			WithMatchKeyDstIP(ipToIpNet("10.10.10.2/24")).
 			Build()
 		expectedCmdArgs := []string{"tc", "-json", "filter", "add", "dev", fakeNetDev}
 		expectedCmdArgs = append(expectedCmdArgs, ingressQdisc.GenCmdLineArgs()...)
@@ -384,7 +387,7 @@ var _ = Describe("TC Cmdline driver tests", func() {
 				WithPriority(200).
 				WithHandle(1).
 				WithChain(0).
-				WithMatchKeyDstIP("10.10.10.2/24").
+				WithMatchKeyDstIP(ipToIpNet("10.10.10.2/24")).
 				WithMatchKeyDstPort(6666).
 				WithMatchKeyIPProto(tctypes.FlowerIPProtoTCP).
 				WithAction(tctypes.NewGenericActionBuiler().WithPass().Build()).

--- a/pkg/tc/filterset_test.go
+++ b/pkg/tc/filterset_test.go
@@ -1,8 +1,10 @@
 package tc_test
 
 import (
+	"github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"net"
 
 	"github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/tc"
 	tctypes "github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/pkg/tc/types"
@@ -10,6 +12,7 @@ import (
 
 var _ = Describe("FilterSetImpl tests", func() {
 	var filterSet tc.FilterSet
+	ipToIpNet := func(ip string) *net.IPNet { ipn, _ := utils.IPToIPNet(ip); return ipn }
 
 	BeforeEach(func() {
 		filterSet = tc.NewFilterSetImpl()
@@ -102,7 +105,7 @@ var _ = Describe("FilterSetImpl tests", func() {
 		BeforeEach(func() {
 			filter = tctypes.NewFlowerFilterBuilder().
 				WithProtocol(tctypes.FilterProtocolIPv4).
-				WithMatchKeyDstIP("192.168.1.2").
+				WithMatchKeyDstIP(ipToIpNet("192.168.1.2")).
 				Build()
 			filterSet.Add(filter)
 		})
@@ -114,7 +117,7 @@ var _ = Describe("FilterSetImpl tests", func() {
 		It("returns false if Filter no in set", func() {
 			otherFilter := tctypes.NewFlowerFilterBuilder().
 				WithProtocol(tctypes.FilterProtocolIPv4).
-				WithMatchKeyDstIP("192.168.2.2").
+				WithMatchKeyDstIP(ipToIpNet("192.168.2.2")).
 				Build()
 			Expect(filterSet.Has(otherFilter)).To(BeFalse())
 		})
@@ -161,7 +164,7 @@ var _ = Describe("FilterSetImpl tests", func() {
 				Build(),
 			tctypes.NewFlowerFilterBuilder().
 				WithProtocol(tctypes.FilterProtocolIPv4).
-				WithMatchKeyDstIP("192.168.1.1").
+				WithMatchKeyDstIP(ipToIpNet("192.168.1.1")).
 				WithAction(
 					tctypes.NewGenericActionBuiler().
 						WithPass().
@@ -255,7 +258,7 @@ var _ = Describe("FilterSetImpl tests", func() {
 				Build(),
 			tctypes.NewFlowerFilterBuilder().
 				WithProtocol(tctypes.FilterProtocolIPv4).
-				WithMatchKeyDstIP("192.168.1.1").
+				WithMatchKeyDstIP(ipToIpNet("192.168.1.1")).
 				WithAction(
 					tctypes.NewGenericActionBuiler().
 						WithPass().
@@ -350,7 +353,7 @@ var _ = Describe("FilterSetImpl tests", func() {
 				Build(),
 			tctypes.NewFlowerFilterBuilder().
 				WithProtocol(tctypes.FilterProtocolIPv4).
-				WithMatchKeyDstIP("192.168.1.1").
+				WithMatchKeyDstIP(ipToIpNet("192.168.1.1")).
 				WithAction(
 					tctypes.NewGenericActionBuiler().
 						WithPass().
@@ -450,7 +453,7 @@ var _ = Describe("FilterSetImpl tests", func() {
 				Build(),
 			tctypes.NewFlowerFilterBuilder().
 				WithProtocol(tctypes.FilterProtocolIPv4).
-				WithMatchKeyDstIP("192.168.1.1").
+				WithMatchKeyDstIP(ipToIpNet("192.168.1.1")).
 				WithAction(
 					tctypes.NewGenericActionBuiler().
 						WithPass().

--- a/pkg/tc/generator/generator_test.go
+++ b/pkg/tc/generator/generator_test.go
@@ -186,7 +186,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 						types.NewFlowerFilterBuilder().
 							WithPriority(prio).
 							WithProtocol(proto).
-							WithMatchKeyDstIP(ip.String()).
+							WithMatchKeyDstIP(ip).
 							WithAction(types.NewGenericActionBuiler().WithPass().Build()).
 							Build())
 					expectedFilters.Add(
@@ -195,7 +195,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 								types.FilterProtocol8021Q)).
 							WithProtocol(types.FilterProtocol8021Q).
 							WithMatchKeyVlanEthType(types.ProtoToFlowerVlanEthType(proto)).
-							WithMatchKeyDstIP(ip.String()).
+							WithMatchKeyDstIP(ip).
 							WithAction(types.NewGenericActionBuiler().WithPass().Build()).
 							Build())
 				}
@@ -284,7 +284,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 							types.NewFlowerFilterBuilder().
 								WithPriority(prio).
 								WithProtocol(proto).
-								WithMatchKeyDstIP(ip.String()).
+								WithMatchKeyDstIP(ip).
 								WithMatchKeyIPProto(types.PortProtocolToFlowerIPProto(port.Protocol)).
 								WithMatchKeyDstPort(port.Number).
 								WithAction(types.NewGenericActionBuiler().WithPass().Build()).
@@ -295,7 +295,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 									types.FilterProtocol8021Q)).
 								WithProtocol(types.FilterProtocol8021Q).
 								WithMatchKeyVlanEthType(types.ProtoToFlowerVlanEthType(proto)).
-								WithMatchKeyDstIP(ip.String()).
+								WithMatchKeyDstIP(ip).
 								WithMatchKeyIPProto(types.PortProtocolToFlowerIPProto(port.Protocol)).
 								WithMatchKeyDstPort(port.Number).
 								WithAction(types.NewGenericActionBuiler().WithPass().Build()).
@@ -366,7 +366,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 						types.NewFlowerFilterBuilder().
 							WithPriority(prio).
 							WithProtocol(proto).
-							WithMatchKeyDstIP(ip.String()).
+							WithMatchKeyDstIP(ip).
 							WithAction(types.NewGenericActionBuiler().WithDrop().Build()).
 							Build())
 					expectedFilters.Add(
@@ -375,7 +375,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 								types.FilterProtocol8021Q)).
 							WithProtocol(types.FilterProtocol8021Q).
 							WithMatchKeyVlanEthType(types.ProtoToFlowerVlanEthType(proto)).
-							WithMatchKeyDstIP(ip.String()).
+							WithMatchKeyDstIP(ip).
 							WithAction(types.NewGenericActionBuiler().WithDrop().Build()).
 							Build())
 				}
@@ -464,7 +464,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 							types.NewFlowerFilterBuilder().
 								WithPriority(prio).
 								WithProtocol(proto).
-								WithMatchKeyDstIP(ip.String()).
+								WithMatchKeyDstIP(ip).
 								WithMatchKeyIPProto(types.PortProtocolToFlowerIPProto(port.Protocol)).
 								WithMatchKeyDstPort(port.Number).
 								WithAction(types.NewGenericActionBuiler().WithDrop().Build()).
@@ -475,7 +475,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 									types.FilterProtocol8021Q)).
 								WithProtocol(types.FilterProtocol8021Q).
 								WithMatchKeyVlanEthType(types.ProtoToFlowerVlanEthType(proto)).
-								WithMatchKeyDstIP(ip.String()).
+								WithMatchKeyDstIP(ip).
 								WithMatchKeyIPProto(types.PortProtocolToFlowerIPProto(port.Protocol)).
 								WithMatchKeyDstPort(port.Number).
 								WithAction(types.NewGenericActionBuiler().WithDrop().Build()).
@@ -552,7 +552,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 						WithPriority(generator.PrioFromBaseAndProtcol(generator.BasePrioPass,
 							types.FilterProtocolIPv4)).
 						WithProtocol(types.FilterProtocolIPv4).
-						WithMatchKeyDstIP(ips[0].String()).
+						WithMatchKeyDstIP(ips[0]).
 						WithMatchKeyIPProto(types.PortProtocolToFlowerIPProto(ports[0].Protocol)).
 						WithMatchKeyDstPort(ports[0].Number).
 						WithAction(types.NewGenericActionBuiler().WithPass().Build()).
@@ -563,7 +563,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 							types.FilterProtocol8021Q)).
 						WithProtocol(types.FilterProtocol8021Q).
 						WithMatchKeyVlanEthType(types.FlowerVlanEthTypeIPv4).
-						WithMatchKeyDstIP(ips[0].String()).
+						WithMatchKeyDstIP(ips[0]).
 						WithMatchKeyIPProto(types.PortProtocolToFlowerIPProto(ports[0].Protocol)).
 						WithMatchKeyDstPort(ports[0].Number).
 						WithAction(types.NewGenericActionBuiler().WithPass().Build()).
@@ -573,7 +573,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 						WithPriority(generator.PrioFromBaseAndProtcol(generator.BasePrioDrop,
 							types.FilterProtocolIPv6)).
 						WithProtocol(types.FilterProtocolIPv6).
-						WithMatchKeyDstIP(ips[2].String()).
+						WithMatchKeyDstIP(ips[2]).
 						WithMatchKeyIPProto(types.PortProtocolToFlowerIPProto(ports[1].Protocol)).
 						WithMatchKeyDstPort(ports[1].Number).
 						WithAction(types.NewGenericActionBuiler().WithDrop().Build()).
@@ -584,7 +584,7 @@ var _ = Describe("SimpleTCGenerator tests", func() {
 							types.FilterProtocol8021Q)).
 						WithProtocol(types.FilterProtocol8021Q).
 						WithMatchKeyVlanEthType(types.FlowerVlanEthTypeIPv6).
-						WithMatchKeyDstIP(ips[2].String()).
+						WithMatchKeyDstIP(ips[2]).
 						WithMatchKeyIPProto(types.PortProtocolToFlowerIPProto(ports[1].Protocol)).
 						WithMatchKeyDstPort(ports[1].Number).
 						WithAction(types.NewGenericActionBuiler().WithDrop().Build()).

--- a/pkg/tc/generator/simple_generator.go
+++ b/pkg/tc/generator/simple_generator.go
@@ -133,7 +133,7 @@ func (s *SimpleTCGenerator) genFiltersWithIPs(ipCidrs []*net.IPNet, basePrio Bas
 			tctypes.NewFlowerFilterBuilder().
 				WithProtocol(proto).
 				WithPriority(PrioFromBaseAndProtcol(basePrio, proto)).
-				WithMatchKeyDstIP(ipCidr.String()).
+				WithMatchKeyDstIP(ipCidr).
 				WithAction(action).
 				Build())
 		// traffic may be tagged, add rule to match on tag traffic as well
@@ -142,7 +142,7 @@ func (s *SimpleTCGenerator) genFiltersWithIPs(ipCidrs []*net.IPNet, basePrio Bas
 				WithProtocol(tctypes.FilterProtocol8021Q).
 				WithPriority(PrioFromBaseAndProtcol(basePrio, tctypes.FilterProtocol8021Q)).
 				WithMatchKeyVlanEthType(tctypes.ProtoToFlowerVlanEthType(proto)).
-				WithMatchKeyDstIP(ipCidr.String()).
+				WithMatchKeyDstIP(ipCidr).
 				WithAction(action).
 				Build())
 	}
@@ -216,7 +216,7 @@ func (s *SimpleTCGenerator) genFiltersWithIPsAndPorts(ipCidrs []*net.IPNet, port
 				tctypes.NewFlowerFilterBuilder().
 					WithProtocol(proto).
 					WithPriority(PrioFromBaseAndProtcol(basePrio, proto)).
-					WithMatchKeyDstIP(ipCidr.String()).
+					WithMatchKeyDstIP(ipCidr).
 					WithMatchKeyIPProto(tctypes.PortProtocolToFlowerIPProto(port.Protocol)).
 					WithMatchKeyDstPort(port.Number).
 					WithAction(action).
@@ -227,7 +227,7 @@ func (s *SimpleTCGenerator) genFiltersWithIPsAndPorts(ipCidrs []*net.IPNet, port
 					WithProtocol(tctypes.FilterProtocol8021Q).
 					WithPriority(PrioFromBaseAndProtcol(basePrio, tctypes.FilterProtocol8021Q)).
 					WithMatchKeyVlanEthType(tctypes.ProtoToFlowerVlanEthType(proto)).
-					WithMatchKeyDstIP(ipCidr.String()).
+					WithMatchKeyDstIP(ipCidr).
 					WithMatchKeyIPProto(tctypes.PortProtocolToFlowerIPProto(port.Protocol)).
 					WithMatchKeyDstPort(port.Number).
 					WithAction(action).

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -120,3 +120,28 @@ func PathExists(path string) (bool, error) {
 	}
 	return false, err
 }
+
+// IsMaskFull returns true if provided mask is all 1s (e.g in CIDR notation, for IPv4 mask its a /32 mask,
+// and for IPv6 mask it is /128
+func IsMaskFull(mask net.IPMask) bool {
+	ones, bits := mask.Size()
+	return ones == bits
+}
+
+// IPToIPNet coverts IP or CIDR formatted string to *net.IPNet.
+// if no CIDR notation, then /32 or /128 mask is assumed for ipv4 and ipv6 respectively.
+func IPToIPNet(ip string) (*net.IPNet, error) {
+	if !strings.Contains(ip, "/") {
+		ipp := net.ParseIP(ip)
+		if ipp == nil {
+			return nil, fmt.Errorf("failed to parse ip: %s", ip)
+		}
+		if ipp.To4() != nil {
+			ip += "/32"
+		} else {
+			ip += "/128"
+		}
+	}
+	_, ipn, err := net.ParseCIDR(ip)
+	return ipn, err
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -259,4 +259,60 @@ var _ = Describe("utils test", func() {
 			Expect(utils.IsIPv4(ip)).To(BeFalse())
 		})
 	})
+
+	Context("IsMaskFull()", func() {
+		It("returns true for full mask", func() {
+			Expect(utils.IsMaskFull(net.IPMask{0xff, 0xff, 0xff, 0xff})).To(BeTrue())
+		})
+
+		It("returns false for partial mask", func() {
+			Expect(utils.IsMaskFull(net.IPMask{0xff, 0xff, 0xff, 0x00})).To(BeFalse())
+		})
+	})
+
+	Context("IPToIPNet()", func() {
+		It("fails if invalid IP", func() {
+			_, err := utils.IPToIPNet("bad/ip")
+			Expect(err).To(HaveOccurred())
+			_, err = utils.IPToIPNet("10.10.10")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns correct ipnet for ipv4", func() {
+			ipn, err := utils.IPToIPNet("10.100.11.1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ipn.String()).To(Equal("10.100.11.1/32"))
+		})
+
+		It("returns correct ipnet for ipv6", func() {
+			ipn, err := utils.IPToIPNet("2001:1234:fafb:abbc:cddc:dccd:af22:22af")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ipn.String()).To(Equal("2001:1234:fafb:abbc:cddc:dccd:af22:22af/128"))
+		})
+
+		It("returns correct ipnet for ipv4 CIDR", func() {
+			ipn, err := utils.IPToIPNet("10.100.11.1/24")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ipn.String()).To(Equal("10.100.11.0/24"))
+		})
+
+		It("returns correct ipnet for ipv6 CIDR", func() {
+			ipn, err := utils.IPToIPNet("2001:1234::/96")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ipn.String()).To(Equal("2001:1234::/96"))
+		})
+
+		It("returns correct ipnet for ipv4 /32 CIDR", func() {
+			ipn, err := utils.IPToIPNet("10.100.11.1/32")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ipn.String()).To(Equal("10.100.11.1/32"))
+		})
+
+		It("returns correct ipnet for ipv6 /128 CIDR", func() {
+			ipn, err := utils.IPToIPNet("2001::22af/128")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ipn.String()).To(Equal("2001::22af/128"))
+		})
+
+	})
 })


### PR DESCRIPTION
currently Flower filter DstIP is a string that is expected
to be either an IP or CIDR wih special handling for transforming
an IP to CIDR. currently this logic was only applied to IPv4 addresses.
Which caused filters with IPv6 /128 mask to be re-applied on interfaces.

To solve this, we take a more structural approach for DstIP field
and use net.IPnet instead of plain string.