### PR TITLE
Fix multiarch image push logic in github actions

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push to GitHub Container Registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: |
@@ -61,10 +61,4 @@ jobs:
         env:
           REPOSITORY: ghcr.io/${{ steps.repo_name.outputs.repository }}
         run: |
-          # Get artifacts from previous steps
-          docker pull ${{ env.REPOSITORY }}:latest-amd64
-          # Create and update manifest
-          docker manifest create ${{ env.REPOSITORY }}:latest ${{ env.REPOSITORY }}:latest-amd64
-          docker manifest annotate ${{ env.REPOSITORY }}:latest ${{ env.REPOSITORY }}:latest-amd64 --arch amd64
-          # Push manifest
-          docker manifest push ${{ env.REPOSITORY }}:latest
+          docker buildx imagetools create -t ${{ env.REPOSITORY }}:latest ${{ env.REPOSITORY }}:latest-amd64

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -30,11 +30,13 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ steps.repo_name.outputs.repository }}
+          tags: |
+            type=ref,event=tag
           flavor: |
             latest=false
 
       - name: Push container image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true
@@ -59,6 +61,8 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v4
         with:
+          tags: |
+            type=ref,event=tag
           images: ghcr.io/${{ steps.repo_name.outputs.repository }}
           flavor: |
             latest=false
@@ -74,14 +78,5 @@ jobs:
         env:
           REPOSITORY: ghcr.io/${{ steps.repo_name.outputs.repository }}
         run: |
-          # Get artifacts from previous steps
-          docker pull ${{ steps.docker_meta.outputs.tags }}-amd64
-          docker pull ${{ env.REPOSITORY }}:stable-amd64
-          # Create and update manifests
-          docker manifest create ${{ steps.docker_meta.outputs.tags }} ${{ steps.docker_meta.outputs.tags }}-amd64
-          docker manifest annotate ${{ steps.docker_meta.outputs.tags }} ${{ steps.docker_meta.outputs.tags }}-amd64 --arch amd64
-          docker manifest create ${{ env.REPOSITORY }}:stable ${{ env.REPOSITORY }}:stable-amd64
-          docker manifest annotate ${{ env.REPOSITORY }}:stable ${{ env.REPOSITORY }}:stable-amd64 --arch amd64
-          # push manifests
-          docker manifest push ${{ steps.docker_meta.outputs.tags }}
-          docker manifest push ${{ env.REPOSITORY }}:stable
+          docker buildx imagetools create -t ${{ env.REPOSITORY }}:stable ${{ env.REPOSITORY }}:stable-amd64
+          docker buildx imagetools create -t ${{ steps.docker_meta.outputs.tags }} ${{ steps.docker_meta.outputs.tags }}-amd64


### PR DESCRIPTION
Use "docker buildx imagetools create" command to create multiarch manifest. This command build and push
a new manifest list from multiple manifests or
manifest lists.

fixes https://github.com/k8snetworkplumbingwg/multi-networkpolicy-tc/issues/50